### PR TITLE
bug: request.messageBody should set with newValue

### DIFF
--- a/Sources/SwiftyRequest/RestRequest.swift
+++ b/Sources/SwiftyRequest/RestRequest.swift
@@ -133,7 +133,7 @@ public class RestRequest {
             return request.httpBody
         }
         set {
-            request.httpBody = messageBody
+            request.httpBody = newValue 
         }
     }
 


### PR DESCRIPTION
The setter for the `RestRequest.messageBody` field should use `newValue`.