### PR TITLE
Bug Fix: Add message body to request

### DIFF
--- a/Sources/SwiftyRequest/RestRequest.swift
+++ b/Sources/SwiftyRequest/RestRequest.swift
@@ -133,7 +133,7 @@ public class RestRequest {
             return request.httpBody
         }
         set {
-            request.httpBody = messageBody
+            request.httpBody = newValue
         }
     }
 


### PR DESCRIPTION
The messageBody setter was not appending the `newValue` to the request, but rather `messageBody`, which of course will always be null. Also, adds a new test case.