### PR TITLE
Bug Fix: Add message body to request

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ SwiftyRequest is an HTTP networking library built for Swift.
 - Multipart form data.
 
 ## Swift version
-The latest version of SwiftyRequest works with the `3.1.1` and newer versions of the Swift binaries. You can download this version of the Swift binaries by following this [link](https://swift.org/download/#releases).
+The latest version of SwiftyRequest works with Swift binaries `3.1.1` and newer. You can download this version of the Swift binaries by following this [link](https://swift.org/download/#releases).
 
 ## Installation
 To leverage the SwiftyRequest package in your Swift application, you should specify a dependency for it in your `Package.swift` file:

--- a/Sources/SwiftyRequest/RestRequest.swift
+++ b/Sources/SwiftyRequest/RestRequest.swift
@@ -133,7 +133,7 @@ public class RestRequest {
             return request.httpBody
         }
         set {
-            request.httpBody = messageBody
+            request.httpBody = newValue
         }
     }
 


### PR DESCRIPTION
The var messageBody setter was not appending the `newValue` to the request, but rather `messageBody`, which of course will always be null. Also, adds a new test case.

Using my personal repo to try to speed up the build.