### PR TITLE
Dynamically identifies String Decoding Type for ResponseString Method

### DIFF
--- a/Sources/SwiftyRequest/RestRequest.swift
+++ b/Sources/SwiftyRequest/RestRequest.swift
@@ -506,13 +506,12 @@ public class RestRequest {
 
             // Retrieve string encoding type
             let encoding = self.getCharacterEncoding(from: response?.allHeaderFields["Content-Type"] as? String)
-    
+
             // parse data as a string
             guard let string = String(data: data, encoding: encoding) else {
                 let result = Result<String>.failure(RestError.serializationError)
                 let dataResponse = RestResponse(request: self.request, response: response, data: nil, result: result)
                 completionHandler(dataResponse)
-                print("failed to decode string")
                 return
             }
 
@@ -636,15 +635,16 @@ public class RestRequest {
     /// - Returns: returns the defined or default String.Encoding.Type
     private func getCharacterEncoding(from contentType: String? = nil) -> String.Encoding {
         guard let text = contentType,
-              let regex = try? NSRegularExpression(pattern: "(?<=charset=).*(?=$|;)"),
+              let regex = try? NSRegularExpression(pattern: "(?<=charset=).*(?=$|\\s)"),
               let match = regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)),
               let range = Range(match.range, in: text) else {
             return .utf8
         }
 
-        let charset = String(text[range])
+        /// Strip whitespace and quotes
+        let charset = String(text[range]).trimmingCharacters(in: CharacterSet(charactersIn: "\" \t"))
 
-        switch charset.lowercased() {
+        switch String(charset).lowercased() {
         case "iso-8859-1": return .isoLatin1
         default: return .utf8
         }

--- a/Sources/SwiftyRequest/RestRequest.swift
+++ b/Sources/SwiftyRequest/RestRequest.swift
@@ -505,7 +505,7 @@ public class RestRequest {
             }
 
             // parse data as a string
-            guard let string = String(data: data, encoding: .utf8) else {
+            guard let string = String(data: data, encoding: .isoLatin1) else {
                 let result = Result<String>.failure(RestError.serializationError)
                 let dataResponse = RestResponse(request: self.request, response: response, data: nil, result: result)
                 completionHandler(dataResponse)

--- a/Sources/SwiftyRequest/RestRequest.swift
+++ b/Sources/SwiftyRequest/RestRequest.swift
@@ -630,6 +630,10 @@ public class RestRequest {
         return nil
     }
 
+    /// Method to identify the charset encoding defined by the Content-Type header
+    /// - Defaults set to .utf8
+    /// - Parameter contentType: The content-type header string
+    /// - Returns: returns the defined or default String.Encoding.Type
     private func getCharacterEncoding(from contentType: String? = nil) -> String.Encoding {
         guard let text = contentType,
               let regex = try? NSRegularExpression(pattern: "(?<=charset=).*(?=$|;)"),

--- a/Sources/SwiftyRequest/RestRequest.swift
+++ b/Sources/SwiftyRequest/RestRequest.swift
@@ -635,8 +635,8 @@ public class RestRequest {
     /// - Returns: returns the defined or default String.Encoding.Type
     private func getCharacterEncoding(from contentType: String? = nil) -> String.Encoding {
         guard let text = contentType,
-              let regex = try? NSRegularExpression(pattern: "(?<=charset=).*(?=$|\\s)"),
-              let match = regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)),
+              let regex = try? NSRegularExpression(pattern: "(?<=charset=).*?(?=$|;|\\s)", options: [.caseInsensitive]),
+              let match = regex.matches(in: text, range: NSRange(text.startIndex..., in: text)).last,
               let range = Range(match.range, in: text) else {
             return .utf8
         }
@@ -648,7 +648,6 @@ public class RestRequest {
         case "iso-8859-1": return .isoLatin1
         default: return .utf8
         }
-
     }
 }
 

--- a/Sources/SwiftyRequest/RestRequest.swift
+++ b/Sources/SwiftyRequest/RestRequest.swift
@@ -642,7 +642,7 @@ public class RestRequest {
         }
 
         /// Strip whitespace and quotes
-        let charset = String(text[range]).trimmingCharacters(in: CharacterSet(charactersIn: "\" \t"))
+        let charset = String(text[range]).trimmingCharacters(in: CharacterSet(charactersIn: "\"").union(.whitespaces))
 
         switch String(charset).lowercased() {
         case "iso-8859-1": return .isoLatin1

--- a/Tests/SwiftyRequestTests/SwiftyRequestTests.swift
+++ b/Tests/SwiftyRequestTests/SwiftyRequestTests.swift
@@ -233,7 +233,7 @@ class SwiftyRequestTests: XCTestCase {
                 return
         }
 
-        let str = String(text[range]).trimmingCharacters(in: CharacterSet(charactersIn: "\" \t"))
+        let str = String(text[range]).trimmingCharacters(in: CharacterSet(charactersIn: "\"").union(.whitespaces))
         assert(String(str).lowercased() == "iso-8859-1")
     }
 

--- a/Tests/SwiftyRequestTests/SwiftyRequestTests.swift
+++ b/Tests/SwiftyRequestTests/SwiftyRequestTests.swift
@@ -228,17 +228,30 @@ class SwiftyRequestTests: XCTestCase {
 
         let expectation = self.expectation(description: "responseString SwiftyRequest test")
 
-        let request = RestRequest(url: apiURL)
-        request.credentials = .apiKey
+        /// Standard
+        let request1 = RestRequest(url: apiURL)
+        request1.credentials = .apiKey
 
-        request.responseString(responseToError: responseToError) { response in
+        request1.responseString(responseToError: responseToError) { response in
             switch response.result {
             case .success(let result):
                 XCTAssertGreaterThan(result.count, 0)
             case .failure(let error):
                 XCTFail("Failed to get weather response String with error: \(error)")
             }
-            expectation.fulfill()
+
+            /// Known example of charset=ISO-8859-1
+            let request2 = RestRequest(url: "http://google.com/")
+            request2.responseString(responseToError: self.responseToError) { response in
+                switch response.result {
+                case .success(let result):
+                    XCTAssertGreaterThan(result.count, 0)
+                case .failure(let error):
+                    XCTFail("Failed to get weather response String with error: \(error)")
+                }
+                expectation.fulfill()
+            }
+
         }
 
         waitForExpectations(timeout: 10)

--- a/Tests/SwiftyRequestTests/SwiftyRequestTests.swift
+++ b/Tests/SwiftyRequestTests/SwiftyRequestTests.swift
@@ -226,10 +226,10 @@ class SwiftyRequestTests: XCTestCase {
 
     func assertCharsetISO8859(response: HTTPURLResponse?) {
         guard let text = response?.allHeaderFields["Content-Type"] as? String,
-            let regex = try? NSRegularExpression(pattern: "(?<=charset=).*(?=$|\\s)"),
-            let match = regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)),
+            let regex = try? NSRegularExpression(pattern: "(?<=charset=).*?(?=$|;|\\s)", options: [.caseInsensitive]),
+            let match = regex.matches(in: text, range: NSRange(text.startIndex..., in: text)).last,
             let range = Range(match.range, in: text) else {
-                assertionFailure("Test no longer valid using URL: \(response?.url?.absoluteString ?? ""). The charset field was not provided.")
+                XCTFail("Test no longer valid using URL: \(response?.url?.absoluteString ?? ""). The charset field was not provided.")
                 return
         }
 

--- a/Tests/SwiftyRequestTests/SwiftyRequestTests.swift
+++ b/Tests/SwiftyRequestTests/SwiftyRequestTests.swift
@@ -234,7 +234,9 @@ class SwiftyRequestTests: XCTestCase {
         }
 
         let str = String(text[range]).trimmingCharacters(in: CharacterSet(charactersIn: "\"").union(.whitespaces))
-        assert(String(str).lowercased() == "iso-8859-1")
+        if String(str).lowercased() != "iso-8859-1" {
+          XCTFail("Test no longer valid using URL: \(response?.url?.absoluteString ?? ""). The charset field was not provided.")
+        }
     }
 
     func testResponseString() {

--- a/Tests/SwiftyRequestTests/SwiftyRequestTests.swift
+++ b/Tests/SwiftyRequestTests/SwiftyRequestTests.swift
@@ -224,6 +224,19 @@ class SwiftyRequestTests: XCTestCase {
 
     }
 
+    func assertCharsetISO8859(response: HTTPURLResponse?) {
+        guard let text = response?.allHeaderFields["Content-Type"] as? String,
+            let regex = try? NSRegularExpression(pattern: "(?<=charset=).*(?=$|\\s)"),
+            let match = regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)),
+            let range = Range(match.range, in: text) else {
+                assertionFailure("Test no longer valid using URL: \(response?.url?.absoluteString ?? ""). The charset field was not provided.")
+                return
+        }
+
+        let str = String(text[range]).trimmingCharacters(in: CharacterSet(charactersIn: "\" \t"))
+        assert(String(str).lowercased() == "iso-8859-1")
+    }
+
     func testResponseString() {
 
         let expectation = self.expectation(description: "responseString SwiftyRequest test")
@@ -243,6 +256,7 @@ class SwiftyRequestTests: XCTestCase {
             /// Known example of charset=ISO-8859-1
             let request2 = RestRequest(url: "http://google.com/")
             request2.responseString(responseToError: self.responseToError) { response in
+                self.assertCharsetISO8859(response: response.response)
                 switch response.result {
                 case .success(let result):
                     XCTAssertGreaterThan(result.count, 0)


### PR DESCRIPTION
Fixes issue #14. 

The current responseString method decodes the data using .utf8. This is the most common serialization option, but several places uses ISO-8859-1 (http://google.com). This PR addresses the issue by identifying the String.Encoding type from the charset field of the Content-Type header. If the encoding type is not defined or not supported, we default to .utf8

There are several other encoding types that I am not familiar with, but we may want to support them or at least some subset of them. I will look into others tomorrow and potentially add them in, but if anyone is aware of any must adds let me know.
