### PR TITLE
Fix Self Signed Certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ SwiftyRequest is an HTTP networking library built for Swift.
 
 ## Swift version
 The 0.0.x releases were tested on macOS and Linux using the Swift 3.1 and 3.1.1 binaries.
-The 1.0.x releases were tested on macOS and Linux using the Swift 4.0.3
+
+The 1.x.x releases were tested on macOS and Linux using the Swift 4.0.3
 
 *NOTE:* Because of issues with URLSession/URLRequest in Swift 4.0, Swift 4.0 projects should use the 0.0.x release of SwiftyRequest.
 

--- a/Sources/SwiftyRequest/RestRequest.swift
+++ b/Sources/SwiftyRequest/RestRequest.swift
@@ -805,7 +805,7 @@ extension RestRequest: URLSessionDelegate {
         switch (method, host) {
         case (NSURLAuthenticationMethodServerTrust, baseHost):
             #if !os(Linux)
-            guard #available(macOS 10.6, *), let trust = challenge.protectionSpace.serverTrust else {
+            guard #available(iOS 3.0, macOS 10.6, *), let trust = challenge.protectionSpace.serverTrust else {
                 Log.warning(warning)
                 fallthrough
             }

--- a/Sources/SwiftyRequest/RestRequest.swift
+++ b/Sources/SwiftyRequest/RestRequest.swift
@@ -794,23 +794,21 @@ extension RestRequest: URLSessionDelegate {
     public func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         let method = challenge.protectionSpace.authenticationMethod
         let host = challenge.protectionSpace.host
-        
+
         guard let url = URLComponents(string: self.url), let baseHost = url.host else {
             completionHandler(.performDefaultHandling, nil)
             return
         }
-        
+
         let warning = "Attempting to establish a secure connection; This is only supported by macOS 10.6 or higher. Resorting to default handling."
 
         switch (method, host) {
         case (NSURLAuthenticationMethodServerTrust, baseHost):
             #if !os(Linux)
-            guard #available(macOS 10.6, *),
-                let trust = challenge.protectionSpace.serverTrust else {
-                    
-                    Log.warning(warning)
-                    fallthrough
-                }
+            guard #available(macOS 10.6, *), let trust = challenge.protectionSpace.serverTrust else {
+                Log.warning(warning)
+                fallthrough
+            }
 
             let credential = URLCredential(trust: trust)
             completionHandler(.useCredential, credential)


### PR DESCRIPTION
The original implementation of self-signed certificate handling only worked for MacOS 10.6, instead of all versions greater than or equal to 10.6.

This fixes availability logic and fixes the test case to use an endpoint using a self-signed certificate