### PR TITLE
Add podspec file

### DIFF
--- a/Sources/SwiftyRequest/RestRequest.swift
+++ b/Sources/SwiftyRequest/RestRequest.swift
@@ -15,7 +15,7 @@
  **/
 
 import Foundation
-import CircuitBreaker
+import CircuitBreakerSwift
 import LoggerAPI
 
 /// Object containing everything needed to build HTTP requests and execute them

--- a/SwiftyRequest.podspec
+++ b/SwiftyRequest.podspec
@@ -8,9 +8,7 @@ Pod::Spec.new do |s|
   s.author     = "IBM"
   s.module_name  = 'SwiftyRequest'
   s.requires_arc = true
-  s.osx.deployment_target = "10.11"
   s.ios.deployment_target = "10.0"
-  s.tvos.deployment_target = "10.0"
   s.source   = { :git => "https://github.com/IBM-Swift/SwiftyRequest.git", :tag => s.version }
   s.source_files = "Sources/SwiftyRequest/*.swift"
   s.pod_target_xcconfig =  {

--- a/SwiftyRequest.podspec
+++ b/SwiftyRequest.podspec
@@ -1,0 +1,21 @@
+
+Pod::Spec.new do |s|
+  s.name        = "SwiftyRequest"
+  s.version     = "1.0.0"
+  s.summary     = "SwiftyRequest is an HTTP networking library built for Swift."
+  s.homepage    = "https://github.com/IBM-Swift/SwiftyRequest"
+  s.license     = { :type => "Apache License, Version 2.0" }
+  s.author     = "IBM"
+  s.module_name  = 'SwiftyRequest'
+  s.requires_arc = true
+  s.osx.deployment_target = "10.11"
+  s.ios.deployment_target = "10.0"
+  s.tvos.deployment_target = "10.0"
+  s.source   = { :git => "https://github.com/IBM-Swift/SwiftyRequest.git", :tag => s.version }
+  s.source_files = "Sources/SwiftyRequest/*.swift"
+  s.pod_target_xcconfig =  {
+        'SWIFT_VERSION' => '4.0.3',
+  }
+  s.dependency 'CircuitBreaker', '~> 5.0.1'
+  s.dependency 'LoggerAPI', '~> 1.7.2'
+end

--- a/Tests/SwiftyRequestTests/SwiftyRequestTests.swift
+++ b/Tests/SwiftyRequestTests/SwiftyRequestTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import CircuitBreaker
+import CircuitBreakerSwift
 @testable import SwiftyRequest
 
 /// URL for the weather underground that many of the tests use


### PR DESCRIPTION
Created and added a pod spec file for future pod creation.

Not to be merged until [this PR](https://github.com/IBM-Swift/LoggerAPI/pull/28) and [this PR](https://github.com/IBM-Swift/CircuitBreaker/pull/43) have been merged, and the LoggerAPI and CircuitBreaker Pod files have been uploaded to the Spec and made publicly available.