### PR TITLE
fix: changed if not os(linux) to if os(mac)

### DIFF
--- a/Sources/SwiftyRequest/RestRequest.swift
+++ b/Sources/SwiftyRequest/RestRequest.swift
@@ -817,7 +817,7 @@ extension RestRequest: URLSessionDelegate {
 
         switch (method, host) {
         case (NSURLAuthenticationMethodClientCertificate, baseHost):
-            #if !os(Linux)
+            #if os(macOS)
             guard let certificateName = self.clientCertificate?.name, let certificatePath = self.clientCertificate?.path else {
                 Log.warning(warning)
                 fallthrough

--- a/Tests/SwiftyRequestTests/SwiftyRequestTests.swift
+++ b/Tests/SwiftyRequestTests/SwiftyRequestTests.swift
@@ -158,7 +158,7 @@ class SwiftyRequestTests: XCTestCase {
     }
     
     func testGetClientCert() {
-        #if !os(Linux)
+        #if os(macOS)
         let expectation = self.expectation(description: "Data Echoed Back")
         let testClientCertificate = ClientCertificate(name: "server.csr", path: "Tests/SwiftyRequestTests/Certificates")
         


### PR DESCRIPTION
This pull requests changed if !os(linux) to if os(mac).
 This is a fix for issue #36 where SecIdentityCreateWithCertificate is only available for macOS and as a result Swiftyrequest was not working on iOS.