### PR TITLE
Make ClientCertificate init scope public

### DIFF
--- a/Sources/SwiftyRequest/RestRequest.swift
+++ b/Sources/SwiftyRequest/RestRequest.swift
@@ -870,4 +870,10 @@ public struct ClientCertificate {
     public let name: String
     /// The path to the client certificate
     public let path: String
+
+    /// Initialize a `ClientCertificate` instance
+    public init(name: String, path: String) {
+      self.name = name
+      self.path = path
+    }
 }


### PR DESCRIPTION
I was trying to initialise this class from another module and ran into the error:

'ClientCertificate' initializer is inaccessible due to 'internal' protection level

From the apple [swift docs](https://docs.swift.org/swift-book/LanguageGuide/AccessControl.html#//apple_ref/doc/uid/TP40014097-CH41-ID3):

> Default Memberwise Initializers for Structure Types
> The default memberwise initializer for a structure type is considered private if any of the structure’s stored properties are private. Likewise, if any of the structure’s stored properties are file private, the initializer is file private. Otherwise, the initializer has an access level of internal.
> 
> As with the default initializer above, if you want a public structure type to be initializable with a memberwise initializer when used in another module, you must provide a public memberwise initializer yourself as part of the type’s definition.

This PR adds provides that public memberwise initializer.