### PR TITLE
Build against Swift 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,11 @@ matrix:
       dist: trusty
       sudo: required
       services: docker
+      env: DOCKER_IMAGE=ubuntu:16.04 SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
+    - os: linux
+      dist: trusty
+      sudo: required
+      services: docker
       env: DOCKER_IMAGE=ubuntu:18.04
     - os: osx
       osx_image: xcode9.2
@@ -43,6 +48,10 @@ matrix:
     - os: osx
       osx_image: xcode10
       sudo: required
+    - os: osx
+      osx_image: xcode10.1
+      sudo: required
+      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
 
 before_install:
   - git clone https://github.com/IBM-Swift/Package-Builder.git

--- a/Sources/SwiftyRequest/CodableExtensions.swift
+++ b/Sources/SwiftyRequest/CodableExtensions.swift
@@ -19,7 +19,7 @@ import Foundation
 //===----------------------------------------------------------------------===//
 // Extensions: JSONEncoder
 //===----------------------------------------------------------------------===//
-internal extension JSONEncoder {
+extension JSONEncoder {
 
     /// Encode an optional object.
     internal func encodeIfPresent<T: Encodable>(_ value: T?) throws -> Data {
@@ -32,7 +32,7 @@ internal extension JSONEncoder {
 //===----------------------------------------------------------------------===//
 // Extensions: KeyedEncodingContainer<DynamicKeys>
 //===----------------------------------------------------------------------===//
-internal extension KeyedEncodingContainer where Key == DynamicKeys {
+extension KeyedEncodingContainer where Key == DynamicKeys {
 
     /// Encode additional properties.
     internal mutating func encode(_ additionalProperties: [String: JSON]) throws {
@@ -57,7 +57,7 @@ internal extension KeyedEncodingContainer where Key == DynamicKeys {
 //===----------------------------------------------------------------------===//
 // Extensions: KeyedDecodingContainer<DynamicKeys>
 //===----------------------------------------------------------------------===//
-internal extension KeyedDecodingContainer where Key == DynamicKeys {
+extension KeyedDecodingContainer where Key == DynamicKeys {
 
     /// Decode additional properties.
     internal func decode(_ type: [String: JSON].Type, excluding keys: [CodingKey]) throws -> [String: JSON] {

--- a/Sources/SwiftyRequest/RestUtilities.swift
+++ b/Sources/SwiftyRequest/RestUtilities.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /// Extension of `Dictionary` type values
-public extension Dictionary {
+extension Dictionary {
 
     /// Performs a transform on the each value of a dictionary
     ///

--- a/Sources/SwiftyRequest/StringExtensions.swift
+++ b/Sources/SwiftyRequest/StringExtensions.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-public extension String {
+extension String {
 
     /// A string url expansion method that replaces templated values in a url, with parameters
     /// The template value pattern to be replaced should look like this `{key}`


### PR DESCRIPTION
Adds testing with a Swift 5 development snapshot. The snapshot is defined in Travis as `SWIFT_DEVELOPMENT_SNAPSHOT` consistently across the IBM-Swift repos, to enable us to automate updating the version.

Resolves Swift 5 compilation warnings relating to redundant access modifier declarations.