### PR TITLE
Fix overwriting of queryItems with nil

### DIFF
--- a/Sources/SwiftyRequest/RestRequest.swift
+++ b/Sources/SwiftyRequest/RestRequest.swift
@@ -250,7 +250,11 @@ public class RestRequest: NSObject  {
             return
         }
 
-        self.queryItems = queryItems
+        // Replace any existing query items with those provided in the queryItems
+        // parameter, if any were given.
+        if let queryItems = queryItems {
+            self.queryItems = queryItems
+        }
 
         response { data, response, error in
 
@@ -295,7 +299,11 @@ public class RestRequest: NSObject  {
             return
         }
 
-        self.queryItems = queryItems
+        // Replace any existing query items with those provided in the queryItems
+        // parameter, if any were given.
+        if let queryItems = queryItems {
+            self.queryItems = queryItems
+        }
 
         response { data, response, error in
 
@@ -372,7 +380,11 @@ public class RestRequest: NSObject  {
             return
         }
 
-        self.queryItems = queryItems
+        // Replace any existing query items with those provided in the queryItems
+        // parameter, if any were given.
+        if let queryItems = queryItems {
+            self.queryItems = queryItems
+        }
 
         response { data, response, error in
 
@@ -428,7 +440,11 @@ public class RestRequest: NSObject  {
             return
         }
 
-        self.queryItems = queryItems
+        // Replace any existing query items with those provided in the queryItems
+        // parameter, if any were given.
+        if let queryItems = queryItems {
+            self.queryItems = queryItems
+        }
 
         response { data, response, error in
 
@@ -505,7 +521,11 @@ public class RestRequest: NSObject  {
             return
         }
 
-        self.queryItems = queryItems
+        // Replace any existing query items with those provided in the queryItems
+        // parameter, if any were given.
+        if let queryItems = queryItems {
+            self.queryItems = queryItems
+        }
 
         response { data, response, error in
 
@@ -570,7 +590,11 @@ public class RestRequest: NSObject  {
             return
         }
 
-        self.queryItems = queryItems
+        // Replace any existing query items with those provided in the queryItems
+        // parameter, if any were given.
+        if let queryItems = queryItems {
+            self.queryItems = queryItems
+        }
 
         response { data, response, error in
 

--- a/Tests/SwiftyRequestTests/SwiftyRequestTests.swift
+++ b/Tests/SwiftyRequestTests/SwiftyRequestTests.swift
@@ -239,7 +239,12 @@ class SwiftyRequestTests: XCTestCase {
         waitForExpectations(timeout: 10)
 
     }
-    
+
+    // TODO: This test does not appear to really test query parameters...
+    // This needs to test that a request made to an API that _requires_ a query
+    // parameter is successful, or that the response somehow indicates that one
+    // was successfully provided. Both methods of setting query items should be
+    // tested (setter on RestRequest, and via param to request.responseObject).
     func testQueryObject() {
         
         let expectation = self.expectation(description: "responseObject SwiftyRequest test")


### PR DESCRIPTION
Resolves #42 

RestRequest provides two ways to configure the query parameters for the request: one is by setting the `queryItems` field, the other is by passing them to one of the `func responseXXX(..., queryItems:)` functions.

If the `queryItems` param is not provided, it defaults to `nil`.  However, that then unconditionally overwrites the values on the RestRequest.  This seems counter-intuitive, and means the only way to use the currently configured queryItems would be to pass it as a parameter, ie. `request.responseObject(..., queryItems: request.queryItems)`.

This PR makes the overwriting conditional on the queryItems param being non-nil.