### PR TITLE
feat: Make RestRequest session public

### DIFF
--- a/Sources/SwiftyRequest/RestRequest.swift
+++ b/Sources/SwiftyRequest/RestRequest.swift
@@ -38,11 +38,11 @@ public class RestRequest: NSObject  {
     // The client certificate for 2-way SSL
     private let clientCertificate: ClientCertificate?
 
-    /// A default `URLSession` instance.
+    /// The `URLSession` instance that will be used to send the requests. Defaults to `URLSession.shared`.
     #if swift(>=4.1)
-    private var session: URLSession = URLSession.shared
+    public var session: URLSession = URLSession.shared
     #else
-    private var session: URLSession = URLSession(configuration: URLSessionConfiguration.default)
+    public var session: URLSession = URLSession(configuration: URLSessionConfiguration.default)
     #endif
 
     // The HTTP Request


### PR DESCRIPTION
This PR makes the `URLSession` variable called session on `RestRequest` public. This was requested in issue #65 so that a user can clear the session cookies for testing. This will also allow users to provide there own configurations to SwiftRequest.