### PR TITLE
Import FoundationNetworking for Swift 5.1

### DIFF
--- a/Sources/SwiftyRequest/RestRequest.swift
+++ b/Sources/SwiftyRequest/RestRequest.swift
@@ -18,6 +18,12 @@ import Foundation
 import CircuitBreaker
 import LoggerAPI
 
+#if swift(>=4.1)
+  #if canImport(FoundationNetworking)
+    import FoundationNetworking
+  #endif
+#endif
+
 /// Object containing everything needed to build and execute HTTP requests.
 public class RestRequest: NSObject  {
 
@@ -244,7 +250,7 @@ public class RestRequest: NSObject  {
             }
         }
         get {
-            if let currentURL = request.url, var urlComponents = URLComponents(url: currentURL, resolvingAgainstBaseURL: false) {
+            if let currentURL = request.url, let urlComponents = URLComponents(url: currentURL, resolvingAgainstBaseURL: false) {
                 return urlComponents.queryItems
             }
             return nil

--- a/Tests/SwiftyRequestTests/SwiftyRequestTests.swift
+++ b/Tests/SwiftyRequestTests/SwiftyRequestTests.swift
@@ -2,6 +2,12 @@ import XCTest
 import CircuitBreaker
 @testable import SwiftyRequest
 
+#if swift(>=4.1)
+  #if canImport(FoundationNetworking)
+    import FoundationNetworking
+  #endif
+#endif
+
 /// URLs for the local test server that these tests use. The TLS certificate
 /// provided by this server is a self-signed certificate that will not be
 /// trusted by default.


### PR DESCRIPTION
Resolve compilation errors and warnings relating to changes in the Swift 5.1 release:
- `import FoundationNetworking` on Linux to access `HTTPCookie` and similar types, due to [changes to Foundation structure](https://forums.swift.org/t/foundationnetworking/24769)
- fix compilation warnings relating to `var`s that were never mutated