### PR TITLE
An easy way to access cookies in RestResponse

### DIFF
--- a/Sources/SwiftyRequest/RestRequest.swift
+++ b/Sources/SwiftyRequest/RestRequest.swift
@@ -17,7 +17,7 @@
 import Foundation
 import CircuitBreaker
 import LoggerAPI
-#if canImport(FoundationNetworking)
+#if swift(>=4.1) && canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
 
@@ -331,6 +331,7 @@ public class RestRequest: NSObject  {
         }
     }
 
+    // Function to get cookies from HTTPURLResponse headers.
     private func getCookies(from response: HTTPURLResponse?) -> [HTTPCookie]? {
         guard let headers = response?.allHeaderFields else {
             return nil
@@ -897,7 +898,7 @@ public struct RestResponse<T> {
     /// The Reponse Result.
     public let result: Result<T>
 
-    // The cookies
+    /// The cookies from HTTPURLResponse
     public let cookies: [HTTPCookie]?
 }
 

--- a/Sources/SwiftyRequest/RestRequest.swift
+++ b/Sources/SwiftyRequest/RestRequest.swift
@@ -327,6 +327,23 @@ public class RestRequest: NSObject  {
             task.resume()
         }
     }
+    private func getCookies(from response: HTTPURLResponse?) -> [HTTPCookie]? {
+        guard let headers = response?.allHeaderFields else{
+            return nil
+        }
+        var headerFields = [String : String]()
+        for (key, value) in headers{
+            guard let key = key as? String, let value = value as? String else{
+                continue }
+            headerFields[key] = value
+        }
+        guard headerFields["Set-Cookie"] != nil else {
+            return nil
+        }
+        let url = response?.url
+        let dummyUrl = URL(string:"http://example.com")!
+        return HTTPCookie.cookies(withResponseHeaderFields: headerFields, for: url ?? dummyUrl)
+    }
 
     /// Request response method with the expected result of a `Data` object.
     ///
@@ -340,7 +357,7 @@ public class RestRequest: NSObject  {
 
         if  let error = performSubstitutions(params: templateParams) {
             let result = Result<Data>.failure(error)
-            let dataResponse = RestResponse(request: request, response: nil, data: nil, result: result)
+            let dataResponse = RestResponse(request: request, response: nil, data: nil, result: result, cookies: nil)
             completionHandler(dataResponse)
             return
         }
@@ -355,19 +372,22 @@ public class RestRequest: NSObject  {
 
             if let error = error {
                 let result = Result<Data>.failure(error)
-                let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
+                let cookies = self.getCookies(from: response)
+                let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result, cookies: cookies)
                 completionHandler(dataResponse)
                 return
             }
 
             guard let data = data else {
                 let result = Result<Data>.failure(RestError.noData)
-                let dataResponse = RestResponse(request: self.request, response: response, data: nil, result: result)
+                let cookies = self.getCookies(from: response)
+                let dataResponse = RestResponse(request: self.request, response: response, data: nil, result: result, cookies: cookies)
                 completionHandler(dataResponse)
                 return
             }
             let result = Result.success(data)
-            let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
+            let cookies = self.getCookies(from: response)
+            let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result, cookies: cookies)
             completionHandler(dataResponse)
         }
     }
@@ -389,7 +409,7 @@ public class RestRequest: NSObject  {
 
         if  let error = performSubstitutions(params: templateParams) {
             let result = Result<T>.failure(error)
-            let dataResponse = RestResponse(request: request, response: nil, data: nil, result: result)
+            let dataResponse = RestResponse(request: request, response: nil, data: nil, result: result, cookies: nil)
             completionHandler(dataResponse)
             return
         }
@@ -404,7 +424,8 @@ public class RestRequest: NSObject  {
 
             if let error = error {
                 let result = Result<T>.failure(error)
-                let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
+                let cookies = self.getCookies(from: response)
+                let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result, cookies: cookies)
                 completionHandler(dataResponse)
                 return
             }
@@ -412,7 +433,8 @@ public class RestRequest: NSObject  {
             if let responseToError = responseToError,
                 let error = responseToError(response, data) {
                 let result = Result<T>.failure(error)
-                let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
+                let cookies = self.getCookies(from: response)
+                let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result, cookies: cookies)
                 completionHandler(dataResponse)
                 return
             }
@@ -420,7 +442,8 @@ public class RestRequest: NSObject  {
             // ensure data is not nil
             guard let data = data else {
                 let result = Result<T>.failure(RestError.noData)
-                let dataResponse = RestResponse(request: self.request, response: response, data: nil, result: result)
+                let cookies = self.getCookies(from: response)
+                let dataResponse = RestResponse(request: self.request, response: response, data: nil, result: result, cookies: cookies)
                 completionHandler(dataResponse)
                 return
             }
@@ -449,7 +472,8 @@ public class RestRequest: NSObject  {
             }
 
             // execute callback
-            let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
+            let cookies = self.getCookies(from: response)
+            let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result, cookies: cookies)
             completionHandler(dataResponse)
         }
     }
@@ -469,7 +493,7 @@ public class RestRequest: NSObject  {
 
         if  let error = performSubstitutions(params: templateParams) {
             let result = Result<T>.failure(error)
-            let dataResponse = RestResponse(request: request, response: nil, data: nil, result: result)
+            let dataResponse = RestResponse(request: request, response: nil, data: nil, result: result, cookies: nil)
             completionHandler(dataResponse)
             return
         }
@@ -484,7 +508,8 @@ public class RestRequest: NSObject  {
 
             if let error = error ?? responseToError?(response, data) {
                 let result = Result<T>.failure(error)
-                let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
+                let cookies = self.getCookies(from: response)
+                let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result, cookies: cookies)
                 completionHandler(dataResponse)
                 return
             }
@@ -492,7 +517,8 @@ public class RestRequest: NSObject  {
             // ensure data is not nil
             guard let data = data else {
                 let result = Result<T>.failure(RestError.noData)
-                let dataResponse = RestResponse(request: self.request, response: response, data: nil, result: result)
+                let cookies = self.getCookies(from: response)
+                let dataResponse = RestResponse(request: self.request, response: response, data: nil, result: result, cookies: cookies)
                 completionHandler(dataResponse)
                 return
             }
@@ -507,7 +533,8 @@ public class RestRequest: NSObject  {
             }
 
             // execute callback
-            let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
+            let cookies = self.getCookies(from: response)
+            let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result, cookies: cookies)
             completionHandler(dataResponse)
         }
     }
@@ -529,7 +556,7 @@ public class RestRequest: NSObject  {
 
         if  let error = performSubstitutions(params: templateParams) {
             let result = Result<[T]>.failure(error)
-            let dataResponse = RestResponse(request: request, response: nil, data: nil, result: result)
+            let dataResponse = RestResponse(request: request, response: nil, data: nil, result: result, cookies: nil)
             completionHandler(dataResponse)
             return
         }
@@ -544,7 +571,8 @@ public class RestRequest: NSObject  {
 
             if let error = error {
                 let result = Result<[T]>.failure(error)
-                let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
+                let cookies = self.getCookies(from: response)
+                let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result, cookies: cookies)
                 completionHandler(dataResponse)
                 return
             }
@@ -552,7 +580,8 @@ public class RestRequest: NSObject  {
             if let responseToError = responseToError,
                 let error = responseToError(response, data) {
                 let result = Result<[T]>.failure(error)
-                let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
+                let cookies = self.getCookies(from: response)
+                let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result, cookies: cookies)
                 completionHandler(dataResponse)
                 return
             }
@@ -560,7 +589,8 @@ public class RestRequest: NSObject  {
             // ensure data is not nil
             guard let data = data else {
                 let result = Result<[T]>.failure(RestError.noData)
-                let dataResponse = RestResponse(request: self.request, response: response, data: nil, result: result)
+                let cookies = self.getCookies(from: response)
+                let dataResponse = RestResponse(request: self.request, response: response, data: nil, result: result, cookies: cookies)
                 completionHandler(dataResponse)
                 return
             }
@@ -590,7 +620,8 @@ public class RestRequest: NSObject  {
             }
 
             // execute callback
-            let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
+            let cookies = self.getCookies(from: response)
+            let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result, cookies: cookies)
             completionHandler(dataResponse)
         }
     }
@@ -610,7 +641,7 @@ public class RestRequest: NSObject  {
 
         if  let error = performSubstitutions(params: templateParams) {
             let result = Result<String>.failure(error)
-            let dataResponse = RestResponse(request: request, response: nil, data: nil, result: result)
+            let dataResponse = RestResponse(request: request, response: nil, data: nil, result: result, cookies: nil)
             completionHandler(dataResponse)
             return
         }
@@ -625,7 +656,8 @@ public class RestRequest: NSObject  {
 
             if let error = error {
                 let result = Result<String>.failure(error)
-                let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
+                let cookies = self.getCookies(from: response)
+                let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result, cookies: cookies)
                 completionHandler(dataResponse)
                 return
             }
@@ -633,7 +665,8 @@ public class RestRequest: NSObject  {
             if let responseToError = responseToError,
                 let error = responseToError(response, data) {
                 let result = Result<String>.failure(error)
-                let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
+                let cookies = self.getCookies(from: response)
+                let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result, cookies: cookies)
                 completionHandler(dataResponse)
                 return
             }
@@ -641,7 +674,8 @@ public class RestRequest: NSObject  {
             // ensure data is not nil
             guard let data = data else {
                 let result = Result<String>.failure(RestError.noData)
-                let dataResponse = RestResponse(request: self.request, response: response, data: nil, result: result)
+                let cookies = self.getCookies(from: response)
+                let dataResponse = RestResponse(request: self.request, response: response, data: nil, result: result, cookies: cookies)
                 completionHandler(dataResponse)
                 return
             }
@@ -652,14 +686,16 @@ public class RestRequest: NSObject  {
             // parse data as a string
             guard let string = String(data: data, encoding: encoding) else {
                 let result = Result<String>.failure(RestError.serializationError)
-                let dataResponse = RestResponse(request: self.request, response: response, data: nil, result: result)
+                let cookies = self.getCookies(from: response)
+                let dataResponse = RestResponse(request: self.request, response: response, data: nil, result: result, cookies: cookies)
                 completionHandler(dataResponse)
                 return
             }
 
             // execute callback
             let result = Result.success(string)
-            let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
+            let cookies = self.getCookies(from: response)
+            let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result, cookies: cookies)
             completionHandler(dataResponse)
         }
     }
@@ -679,7 +715,7 @@ public class RestRequest: NSObject  {
 
         if  let error = performSubstitutions(params: templateParams) {
             let result = Result<Void>.failure(error)
-            let dataResponse = RestResponse(request: request, response: nil, data: nil, result: result)
+            let dataResponse = RestResponse(request: request, response: nil, data: nil, result: result, cookies: nil)
             completionHandler(dataResponse)
             return
         }
@@ -694,21 +730,24 @@ public class RestRequest: NSObject  {
 
             if let error = error {
                 let result = Result<Void>.failure(error)
-                let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
+                let cookies = self.getCookies(from: response)
+                let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result, cookies: cookies)
                 completionHandler(dataResponse)
                 return
             }
 
             if let responseToError = responseToError, let error = responseToError(response, data) {
                 let result = Result<Void>.failure(error)
-                let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
+                let cookies = self.getCookies(from: response)
+                let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result, cookies: cookies)
                 completionHandler(dataResponse)
                 return
             }
 
             // execute callback
             let result = Result<Void>.success(())
-            let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result)
+            let cookies = self.getCookies(from: response)
+            let dataResponse = RestResponse(request: self.request, response: response, data: data, result: result, cookies: cookies)
             completionHandler(dataResponse)
         }
     }
@@ -852,6 +891,9 @@ public struct RestResponse<T> {
 
     /// The Reponse Result.
     public let result: Result<T>
+
+    // The cookies
+    public let cookies: [HTTPCookie]?
 }
 
 /// Enum to differentiate a success or failure.

--- a/Sources/SwiftyRequest/RestRequest.swift
+++ b/Sources/SwiftyRequest/RestRequest.swift
@@ -17,11 +17,6 @@
 import Foundation
 import CircuitBreaker
 import LoggerAPI
-#if swift(>=4.1)
-    #if canImport(FoundationNetworking)
-        import FoundationNetworking
-    #endif
-#endif
 
 #if swift(>=4.1)
   #if canImport(FoundationNetworking)

--- a/Sources/SwiftyRequest/RestRequest.swift
+++ b/Sources/SwiftyRequest/RestRequest.swift
@@ -17,8 +17,10 @@
 import Foundation
 import CircuitBreaker
 import LoggerAPI
-#if swift(>=4.1) && canImport(FoundationNetworking)
-import FoundationNetworking
+#if swift(>=4.1)
+    #if canImport(FoundationNetworking)
+        import FoundationNetworking
+    #endif
 #endif
 
 #if swift(>=4.1)

--- a/Sources/SwiftyRequest/RestRequest.swift
+++ b/Sources/SwiftyRequest/RestRequest.swift
@@ -17,6 +17,9 @@
 import Foundation
 import CircuitBreaker
 import LoggerAPI
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 #if swift(>=4.1)
   #if canImport(FoundationNetworking)

--- a/Sources/SwiftyRequest/RestRequest.swift
+++ b/Sources/SwiftyRequest/RestRequest.swift
@@ -327,14 +327,16 @@ public class RestRequest: NSObject  {
             task.resume()
         }
     }
+
     private func getCookies(from response: HTTPURLResponse?) -> [HTTPCookie]? {
-        guard let headers = response?.allHeaderFields else{
+        guard let headers = response?.allHeaderFields else {
             return nil
         }
         var headerFields = [String : String]()
-        for (key, value) in headers{
-            guard let key = key as? String, let value = value as? String else{
-                continue }
+        for (key, value) in headers {
+            guard let key = key as? String, let value = value as? String else {
+                continue
+            }
             headerFields[key] = value
         }
         guard headerFields["Set-Cookie"] != nil else {

--- a/TestServer/Sources/TestServer/main.swift
+++ b/TestServer/Sources/TestServer/main.swift
@@ -2,6 +2,9 @@ import Kitura
 import HeliumLogger
 import FileKit
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 func cookieHandler(request: RouterRequest, response: RouterResponse, next: @escaping () -> Void) throws {
     let number = request.parameters["number"].map { Int($0) ?? 0 } ?? 0

--- a/TestServer/Sources/TestServer/main.swift
+++ b/TestServer/Sources/TestServer/main.swift
@@ -2,8 +2,10 @@ import Kitura
 import HeliumLogger
 import FileKit
 import Foundation
-#if canImport(FoundationNetworking)
-import FoundationNetworking
+#if swift(>=4.1)
+    #if canImport(FoundationNetworking)
+        import FoundationNetworking
+    #endif
 #endif
 
 func cookieHandler(request: RouterRequest, response: RouterResponse, next: @escaping () -> Void) throws {

--- a/TestServer/Sources/TestServer/main.swift
+++ b/TestServer/Sources/TestServer/main.swift
@@ -6,15 +6,15 @@ import Foundation
 func cookieHandler(request: RouterRequest, response: RouterResponse, next: @escaping () -> Void) throws {
     let number = request.parameters["number"].map { Int($0) ?? 0 } ?? 0
     for no in 0..<number {
-    var cookieProps: [HTTPCookiePropertyKey: Any]
-    cookieProps = [
-        HTTPCookiePropertyKey.domain: "localhost",
-        HTTPCookiePropertyKey.path: "/",
-        HTTPCookiePropertyKey.name: "name\(no)",
-        HTTPCookiePropertyKey.value: "value\(no)",
-    ]
-    let cookie = HTTPCookie(properties: cookieProps)
-    response.cookies["name\(no)"] = cookie
+        var cookieProps: [HTTPCookiePropertyKey: Any]
+        cookieProps = [
+            HTTPCookiePropertyKey.domain: "localhost",
+            HTTPCookiePropertyKey.path: "/",
+            HTTPCookiePropertyKey.name: "name\(no)",
+            HTTPCookiePropertyKey.value: "value\(no)",
+        ]
+        let cookie = HTTPCookie(properties: cookieProps)
+        response.cookies["name\(no)"] = cookie
     }
     try response.status(.OK).end()
 }

--- a/Tests/SwiftyRequestTests/SwiftyRequestTests.swift
+++ b/Tests/SwiftyRequestTests/SwiftyRequestTests.swift
@@ -140,7 +140,7 @@ class SwiftyRequestTests: XCTestCase {
         request.responseData { response in
             switch response.result {
             case .success :
-                let cookies = response.cookies
+                let cookies = response.cookies?.sorted{ $0.name < $1.name }
                 XCTAssertEqual(cookies?.count, 2)
                 for no in [0,1] {
                     XCTAssertEqual(cookies?[no].name, "name\(no)")

--- a/Tests/SwiftyRequestTests/SwiftyRequestTests.swift
+++ b/Tests/SwiftyRequestTests/SwiftyRequestTests.swift
@@ -183,7 +183,7 @@ class SwiftyRequestTests: XCTestCase {
             switch response.result {
             case .success :
                 let cookies = response.cookies
-                XCTAssertNil(cookies, "No cookies expected in response but found \(cookies?.count) cookies.")
+                XCTAssertNil(cookies, "No cookies expected in response but found \(cookies!.count) cookies.")
             case .failure(let error):
                 XCTFail("Failed to get data response with error: \(error)")
             }

--- a/Tests/SwiftyRequestTests/SwiftyRequestTests.swift
+++ b/Tests/SwiftyRequestTests/SwiftyRequestTests.swift
@@ -82,7 +82,10 @@ class SwiftyRequestTests: XCTestCase {
         ("testQueryParamUpdating", testQueryParamUpdating),
         ("testQueryParamUpdatingObject", testQueryParamUpdatingObject),
         ("testQueryTemplateParams", testQueryTemplateParams),
-        ("testQueryTemplateParamsObject", testQueryTemplateParamsObject)
+        ("testQueryTemplateParamsObject", testQueryTemplateParamsObject),
+        ("testMultipleCookies",testMultipleCookies),
+        ("testCookie",testCookie),
+        ("testNoCookies",testNoCookies)
     ]
 
     // Enable logging output for tests
@@ -129,6 +132,66 @@ class SwiftyRequestTests: XCTestCase {
     }
 
     // MARK: SwiftyRequest Tests
+
+    func testMultipleCookies() {
+        let expectation = self.expectation(description: "testtestMultipleCookies")
+        let request = RestRequest(method: .get, url:"http://localhost:8080/cookies/2")
+        request.credentials = .apiKey
+        request.responseData { response in
+            switch response.result {
+            case .success :
+                let cookies = response.cookies
+                XCTAssertEqual(cookies?.count, 2)
+                for no in [0,1] {
+                    XCTAssertEqual(cookies?[no].name, "name\(no)")
+                    XCTAssertEqual(cookies?[no].value, "value\(no)")
+                }
+            case .failure(let error):
+                XCTFail("Failed to get cookies with error: \(error)")
+            }
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 10)
+    }
+
+    func testCookie() {
+        let expectation = self.expectation(description: "testCookie")
+        let request = RestRequest(method: .get, url:"http://localhost:8080/cookies/1")
+        request.credentials = .apiKey
+        request.responseData { response in
+            switch response.result {
+            case .success :
+                let cookies = response.cookies
+                XCTAssertEqual(cookies?.count, 1)
+                XCTAssertEqual(cookies?[0].name, "name0")
+                XCTAssertEqual(cookies?[0].value, "value0")
+            case .failure(let error):
+                XCTFail("Failed to get cookies with error: \(error)")
+            }
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 10)
+    }
+
+    func testNoCookies() {
+        let expectation = self.expectation(description: "testNoCookies")
+        let request = RestRequest(method: .get, url:"http://localhost:8080/cookies/0")
+        request.credentials = .apiKey
+        request.responseData { response in
+            switch response.result {
+            case .success :
+                let cookies = response.cookies
+                XCTAssertNil(cookies, "No cookies expected in response but found \(cookies?.count) cookies.")
+            case .failure(let error):
+                XCTFail("Failed to get data response with error: \(error)")
+            }
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 10)
+    }
 
     func testInsecureConnection() {
         let expectation = self.expectation(description: "Insecure Connection test")


### PR DESCRIPTION
Currently, cookies are sent as a part `HTTPURLResponse` headers. To access cookies, they have to be fished out of these headers. The `getCookies(from: )` function takes `HTTPURLResponse` and returns HTTPCookie(s). New public property `cookies` is added into `RestResponse` structure. Cookies return by getCookies(from: )` are added into `cookies`. The cookies can be accessed by accessing 'cookies` property of `RestResponse`.