### PR TITLE
Add OSX 10.10 deployment target for podspec.

### DIFF
--- a/SwiftyRequest.podspec
+++ b/SwiftyRequest.podspec
@@ -8,6 +8,7 @@ Pod::Spec.new do |s|
   s.author     = "IBM"
   s.module_name  = 'SwiftyRequest'
   s.ios.deployment_target = "10.0"
+  s.osx.deployment_target = "10.10"
   s.source   = { :git => "https://github.com/IBM-Swift/SwiftyRequest.git", :tag => s.version }
   s.source_files = "Sources/**/*.swift"
   s.dependency 'LoggerAPI', '~> 1.7'


### PR DESCRIPTION
This PR adds the support for MacOS with CocoaPods dependency manager.
It requires the PR#53 from CircuitBraker (https://github.com/IBM-Swift/CircuitBreaker/pull/53) in order to work.