### PR TITLE
feat: Allow access to EventLoopGroup

### DIFF
--- a/Sources/SwiftyRequest/RestError.swift
+++ b/Sources/SwiftyRequest/RestError.swift
@@ -55,6 +55,9 @@ public struct RestError: Error {
     /// An HTTPClient error occurred before invoking the request. See the `error` property for the underlying error.
     public static let httpClientError = RestError(.otherError, description: "HTTPClientError")
 
+    /// An attempt was made to reassign the global `EventLoopGroup` used by `RestRequest` after it had already been initialized.
+    public static let eventLoopGroupAlreadySet = RestError(.eventLoopGroupAlreadySet, description: "The global EventLoopGroup has already been initialized")
+
     /// Another error occurred before invoking the request. See the `error` property for the underlying error.
     public static let otherError = RestError(.otherError, description: "Other Error")
 
@@ -96,7 +99,7 @@ public struct RestError: Error {
     private let internalError: InternalError
     
     private enum InternalError {
-        case noData, serializationError, encodingError, decodingError, fileManagerError, invalidFile, invalidSubstitution, downloadError, errorStatusCode, invalidURL, httpClientError, otherError
+        case noData, serializationError, encodingError, decodingError, fileManagerError, invalidFile, invalidSubstitution, downloadError, errorStatusCode, invalidURL, httpClientError, eventLoopGroupAlreadySet, otherError
     }
 
     private let _description: String

--- a/Tests/SwiftyRequestTests/SwiftyRequestTests.swift
+++ b/Tests/SwiftyRequestTests/SwiftyRequestTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import CircuitBreaker
 import NIOSSL
+import NIO
 @testable import SwiftyRequest
 
 #if swift(>=4.1)
@@ -71,6 +72,7 @@ class SwiftyRequestTests: XCTestCase {
         ("testBasicAuthenticationFails", testBasicAuthenticationFails),
         ("testTokenAuthentication", testTokenAuthentication),
         ("testHeaders", testHeaders),
+        ("testEventLoopGroup", testEventLoopGroup),
     ]
 
     // Enable logging output for tests
@@ -1090,6 +1092,26 @@ class SwiftyRequestTests: XCTestCase {
             expectation.fulfill()
         }
         waitForExpectations(timeout: 10)
+    }
+
+    // MARK: Test configuration parameters
+
+    func testEventLoopGroup() {
+        let myELG = MultiThreadedEventLoopGroup(numberOfThreads: 2)
+
+        // Clear the global ELG
+        RestRequest.resetELG()
+
+        // Access default ELG, and verify it cannot then be set
+        XCTAssertNotNil(RestRequest.globalELG)
+        XCTAssertThrowsError(try RestRequest.setGlobalELG(myELG), "Global ELG should not have been set again")
+
+        // Clear the global ELG
+        RestRequest.resetELG()
+
+        // Verify that the ELG can be set once and only once
+        XCTAssertNoThrow(try RestRequest.setGlobalELG(myELG), "Global ELG could not be set")
+        XCTAssertThrowsError(try RestRequest.setGlobalELG(myELG), "Global ELG should not have been set again")
     }
 
 }

--- a/Tests/SwiftyRequestTests/SwiftyRequestTests.swift
+++ b/Tests/SwiftyRequestTests/SwiftyRequestTests.swift
@@ -1100,14 +1100,14 @@ class SwiftyRequestTests: XCTestCase {
         let myELG = MultiThreadedEventLoopGroup(numberOfThreads: 2)
 
         // Clear the global ELG
-        RestRequest.resetELG()
+        RestRequest._testOnly_resetELG()
 
         // Access default ELG, and verify it cannot then be set
         XCTAssertNotNil(RestRequest.globalELG)
         XCTAssertThrowsError(try RestRequest.setGlobalELG(myELG), "Global ELG should not have been set again")
 
         // Clear the global ELG
-        RestRequest.resetELG()
+        RestRequest._testOnly_resetELG()
 
         // Verify that the ELG can be set once and only once
         XCTAssertNoThrow(try RestRequest.setGlobalELG(myELG), "Global ELG could not be set")


### PR DESCRIPTION
`RestRequest` uses a global EventLoopGroup containing a single thread.  This is sufficient for simple applications, however for highly parallel applications it creates a bottleneck.

This PR:
- Updates the default `EventLoopGroup` to use 1 thread per available processor,
- Permits read access to the `RestRequest.globalELG` property,
- Permits customization of the ELG via the `RestRequest.setGlobalELG()` function.

The `globalELG` is initialized lazily to its default value.  It can be customized, once and only once, by calling `setGlobalELG()` _before_ `globalELG` is accessed (or a request is issued).

### Setting a common EventLoopGroup for SwiftyRequest and Kitura

`Kitura-NIO` users may choose to use the same `EventLoopGroup` for both Kitura and SwiftyRequest. For example:

```swift
let server = Kitura.addHTTPServer(...)
let myEventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 4)
do {
  try RestRequest.setGlobalELG(myEventLoopGroup)
  try server.setEventLoopGroup(myEventLoopGroup)
} catch {
  // Handle error: ELG was already set
}
```

### Setting an EventLoopGroup with multiple threads per processor

Example:
```swift
#if os(Linux)
import Glibc
#else
import Darwin
#endif

#if os(Linux)
let numberOfCores = Int(linux_sched_getaffinity())
let myEventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: numberOfCores > 0 ? numberOfCores * 2 : System.coreCount * 2)
#else
let myEventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount * 2)
#endif
```