### PR TITLE
Feature/httpclient configuration

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/IBM-Swift/CircuitBreaker.git", from: "5.0.0"),
         .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", from: "1.8.0"),
-        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.0.0"),
+        .package(url: "https://github.com/StrangeDays/async-http-client.git", .branch("master"))
     ],
     targets: [
         .target(

--- a/Sources/SwiftyRequest/RestRequest.swift
+++ b/Sources/SwiftyRequest/RestRequest.swift
@@ -414,8 +414,7 @@ public class RestRequest {
             certificateVerification: (insecure ? .none : .fullVerification),
             certificateChain: chain, privateKey: key)
 
-        _configuration.tlsConfiguration = tlsConfiguration
-        _configuration.ignoreUncleanSSLShutdown = true
+        _configuration.tlsConfiguration = tlsConfiguration        
         _configuration.timeout = timeout ?? HTTPClient.Configuration.Timeout()
 
         return HTTPClient(eventLoopGroupProvider: .shared(eventLoopGroup ?? globalELG), configuration: _configuration)


### PR DESCRIPTION
For Firebase  RestRequest there's a need of `ignoreUncleanSSLShutdown` being `true`

Anyway it should be possible to adopt the HTTPClient.Configuration